### PR TITLE
Add labels for inputs

### DIFF
--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -40,20 +40,26 @@ export default function AdminLogin({ onBack, onLoginSuccess }: AdminLoginProps) 
     <div className="flex justify-center items-center h-full relative">
       <div className="w-full max-w-sm bg-white p-6 rounded-lg shadow space-y-4">
         <h1 className="text-xl font-semibold text-center">로그인</h1>
-        <Input
-          type="text"
-          placeholder="아이디"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          className="text-base"
-        />
-        <Input
-          type="password"
-          placeholder="비밀번호"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="text-base"
-        />
+        <label className="block space-y-1">
+          <span className="sr-only">아이디</span>
+          <Input
+            type="text"
+            placeholder="아이디"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="text-base"
+          />
+        </label>
+        <label className="block space-y-1">
+          <span className="sr-only">비밀번호</span>
+          <Input
+            type="password"
+            placeholder="비밀번호"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="text-base"
+          />
+        </label>
         <div className="flex justify-between">
           <Button onClick={onBack} variant="outline" className="text-base">
             돌아가기

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -95,11 +95,16 @@ export default function GlobalItemManager() {
       <div className="border rounded p-4 shadow bg-white space-y-3">
         <h3 className="font-semibold text-lg">기념품 항목 추가</h3>
 
-        <Input
-          placeholder="기념품 이름"
-          value={newItem.name ?? ""}
-          onChange={(e) => setNewItem((prev) => ({ ...prev, name: e.target.value }))}
-        />
+        <label className="block space-y-1">
+          <span className="sr-only">기념품 이름</span>
+          <Input
+            placeholder="기념품 이름"
+            value={newItem.name ?? ""}
+            onChange={(e) =>
+              setNewItem((prev) => ({ ...prev, name: e.target.value }))
+            }
+          />
+        </label>
 
         <Textarea
           placeholder="기념품 설명 (선택)"
@@ -189,13 +194,16 @@ export default function GlobalItemManager() {
         <Modal onClose={() => setShowEditModal(false)}>
           <h3 className="text-lg font-semibold mb-4">기념품 편집</h3>
 
-          <Input
-            value={editingItem.name}
-            onChange={(e) =>
-              setEditingItem({ ...editingItem, name: e.target.value })
-            }
-            placeholder="이름"
-          />
+          <label className="block space-y-1">
+            <span className="sr-only">이름</span>
+            <Input
+              value={editingItem.name}
+              onChange={(e) =>
+                setEditingItem({ ...editingItem, name: e.target.value })
+              }
+              placeholder="이름"
+            />
+          </label>
 
           <Textarea
             value={editingItem.description ?? ""}


### PR DESCRIPTION
## Summary
- wrap admin login inputs with labels
- add labels around input fields in the global item manager

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7456fdbc832bb3ce34efe620cec0