### PR TITLE
Add aria-labels to icon buttons

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -28,6 +28,7 @@ export default function Modal({ children, onClose }: Props) {
         <button
           onClick={onClose}
           className="absolute top-3 right-3 text-gray-400 hover:text-black text-2xl font-bold w-10 h-10 flex items-center justify-center rounded-full hover:bg-gray-200 transition"
+          aria-label="닫기"
         >
           ✕
         </button>

--- a/src/modals/AdminItems.tsx
+++ b/src/modals/AdminItems.tsx
@@ -161,6 +161,7 @@ export default function AdminItems({ locationId }: Props) {
                   variant="ghost"
                   onClick={() => moveItem(category, index, "up")}
                   disabled={index === 0}
+                  aria-label="위로 이동"
                 >
                   <ArrowUp size={16} />
                 </Button>
@@ -169,6 +170,7 @@ export default function AdminItems({ locationId }: Props) {
                   variant="ghost"
                   onClick={() => moveItem(category, index, "down")}
                   disabled={index === filtered.length - 1}
+                  aria-label="아래로 이동"
                 >
                   <ArrowDown size={16} />
                 </Button>
@@ -212,6 +214,7 @@ export default function AdminItems({ locationId }: Props) {
                   variant="ghost"
                   className="text-red-500 ml-auto"
                   onClick={() => handleDelete(item.id)}
+                  aria-label="항목 삭제"
                 >
                   <Trash2 size={16} />
                 </Button>

--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -81,6 +81,7 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
             <button
               className="absolute top-1 right-1 bg-white p-1 rounded-full shadow hidden group-hover:block"
               onClick={() => handleDelete(url)}
+              aria-label="이미지 삭제"
             >
               <Trash2 size={14} className="text-red-500" />
             </button>

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -423,6 +423,7 @@ export default function AdminRecords() {
                     handleDelete(record.id);
                   }}
                   className="absolute top-3 right-3 text-gray-400 hover:text-red-500"
+                  aria-label="기록 삭제"
                 >
                   <Trash2 size={16} />
                 </button>

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -157,6 +157,7 @@ export default function GlobalItemManager() {
                     setEditingItem(item);
                     setShowEditModal(true);
                   }}
+                  aria-label="편집"
                 >
                   <Pencil size={16} />
                 </Button>
@@ -164,6 +165,7 @@ export default function GlobalItemManager() {
                   variant="ghost"
                   onClick={() => handleDelete(item.id)}
                   className="text-red-500"
+                  aria-label="삭제"
                 >
                   <Trash2 size={16} />
                 </Button>

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -89,6 +89,7 @@ export default function MainLayout() {
           setSidebarOpen(!sidebarOpen);
         }}
         className="fixed top-4 left-4 z-40 p-2 bg-white rounded-full shadow-md"
+        aria-label="메뉴 열기"
       >
         <Menu />
       </button>
@@ -108,6 +109,7 @@ export default function MainLayout() {
             <button
               onClick={() => setSidebarOpen(false)}
               className="text-gray-500 hover:text-black"
+              aria-label="메뉴 닫기"
             >
               &times;
             </button>


### PR DESCRIPTION
## Summary
- add aria-labels for sidebar buttons in `MainLayout`
- label modal close button for screen readers
- label admin item controls
- ensure record and item manager buttons have aria-labels
- label image selector delete buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d74559820832b9b21709cc7baf37c