### PR TITLE
Improve image alt text

### DIFF
--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -67,25 +67,30 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
       <h2 className="text-lg font-semibold mb-4">이미지 선택</h2>
 
       <div className="grid grid-cols-3 gap-3 max-h-[400px] overflow-y-auto">
-        {images.map((url) => (
-          <div key={url} className="relative group border rounded p-1">
-            <img
-              src={url}
-              alt="img"
-              className="w-full aspect-square object-contain rounded cursor-pointer"
-              onClick={() => {
-                onSelect(url);
-                onClose();
-              }}
-            />
-            <button
-              className="absolute top-1 right-1 bg-white p-1 rounded-full shadow hidden group-hover:block"
-              onClick={() => handleDelete(url)}
-            >
-              <Trash2 size={14} className="text-red-500" />
-            </button>
-          </div>
-        ))}
+        {images.map((url) => {
+          const fileName = url.split("/").pop()?.split("?")[0] || "image";
+          const baseName = fileName.replace(/\.[^/.]+$/, "").replace(/^\d+_/, "");
+          return (
+            <div key={url} className="relative group border rounded p-1">
+              <img
+                src={url}
+                alt={baseName}
+                className="w-full aspect-square object-contain rounded cursor-pointer"
+                onClick={() => {
+                  onSelect(url);
+                  onClose();
+                }}
+              />
+              <button
+                className="absolute top-1 right-1 bg-white p-1 rounded-full shadow hidden group-hover:block"
+                onClick={() => handleDelete(url)}
+              >
+                <Trash2 size={14} className="text-red-500" />
+              </button>
+            </div>
+          );
+        })}
+
       </div>
 
       <div className="mt-4">

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -115,7 +115,7 @@ export default function GlobalItemManager() {
           {newItem.image_url && (
             <img
               src={newItem.image_url}
-              alt="선택된 이미지"
+              alt={newItem.name ? `${newItem.name} 이미지` : "선택된 기념품 이미지"}
               className="w-32 h-20 object-contain border rounded"
             />
           )}
@@ -213,6 +213,7 @@ export default function GlobalItemManager() {
             {editingItem.image_url && (
               <img
                 src={editingItem.image_url}
+                alt={editingItem.name ? `${editingItem.name} 이미지` : "편집 중인 기념품 이미지"}
                 className="w-32 h-20 object-contain border rounded"
               />
             )}


### PR DESCRIPTION
## Summary
- derive alt text in `ImageSelectorModal` from the image filename
- add dynamic alt text in `GlobalItemManager` for preview and edit images

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d74587b94832b9791d82dec500462