### PR TITLE
Add loader component and loading states

### DIFF
--- a/src/components/ui/Loader.tsx
+++ b/src/components/ui/Loader.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface LoaderProps {
+  className?: string;
+}
+
+export default function Loader({ className }: LoaderProps) {
+  return (
+    <div
+      className={cn(
+        "inline-block h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-redCross",
+        className
+      )}
+    />
+  );
+}
+

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import Loader from "@/components/ui/Loader";
 import { Trash2 } from "lucide-react";
 import { createClient } from "@supabase/supabase-js";
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
@@ -27,6 +28,7 @@ export default function AdminRecords() {
   const [selectedRecords, setSelectedRecords] = useState<Set<string>>(new Set());
   const [showModal, setShowModal] = useState(false);
   const [highlightedRecords, setHighlightedRecords] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
   const [startDate, setStartDate] = useState<Date>(() => {
     const stored = localStorage.getItem("startDate");
     return stored ? new Date(stored) : new Date();
@@ -46,6 +48,7 @@ export default function AdminRecords() {
 
   useEffect(() => {
     const fetchData = async () => {
+      setLoading(true);
       const { data: recordsData } = await supabase.from("gift_records").select("*");
       const { data: locationData } = await supabase.from("donation_locations").select("*");
 
@@ -59,6 +62,7 @@ export default function AdminRecords() {
       }
 
       setLocations(locationData ?? []);
+      setLoading(false);
     };
 
     fetchData();
@@ -229,7 +233,13 @@ export default function AdminRecords() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-8">
-      <div className="flex flex-col gap-4">
+      {loading ? (
+        <div className="flex justify-center py-10">
+          <Loader className="h-8 w-8" />
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-4">
         {/* 날짜 필터 */}
         <div className="space-y-2">
           <div className="flex items-center gap-4">
@@ -455,6 +465,8 @@ export default function AdminRecords() {
             );
           })}
         </div>
+      )}
+      </>
       )}
       {showModal && (
         <Modal onClose={() => setShowModal(false)}>

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -4,6 +4,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import Loader from "@/components/ui/Loader";
 import { Trash2, Pencil } from "lucide-react";
 import ImageSelectorModal from "@/modals/ImageSelectorModal";
 import Modal from "@/components/ui/Modal";
@@ -122,7 +123,13 @@ export default function GlobalItemManager() {
         </div>
 
         <Button onClick={handleAdd} disabled={loading}>
-          {loading ? "추가 중..." : "기념품 추가"}
+          {loading ? (
+            <span className="flex items-center gap-2">
+              <Loader className="h-4 w-4" /> 추가 중...
+            </span>
+          ) : (
+            "기념품 추가"
+          )}
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary
- add a reusable `Loader` spinner component
- show loading spinner while AdminRecords fetches data
- display spinner when adding items in GlobalItemManager

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7459f7c8832b9297ef563852d33a