### PR TITLE
Add Toast component and replace alerts

### DIFF
--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface ToastItem {
+  id: number;
+  message: string;
+}
+
+interface ToastContextValue {
+  show: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const show = (message: string) => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={cn(
+              "bg-gray-900 text-white px-4 py-2 rounded shadow-md transition-opacity"
+            )}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx.show;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { ToastProvider } from "@/components/ui/Toast";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </React.StrictMode>
 );

--- a/src/modals/AdminItems.tsx
+++ b/src/modals/AdminItems.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { ArrowUp, ArrowDown, Trash2 } from "lucide-react";
 import { createClient } from "@supabase/supabase-js";
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import { useToast } from "@/components/ui/Toast";
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
@@ -32,6 +33,7 @@ export default function AdminItems({ locationId }: Props) {
   const [locationItems, setLocationItems] = useState<LocationGiftItem[]>([]);
   const [newGiftItemId, setNewGiftItemId] = useState<string>("");
   const [newCategory, setNewCategory] = useState<"A" | "B">("A");
+  const toast = useToast();
 
   const fetchData = async () => {
     const { data: giftData } = await supabase.from("gift_items").select("*");
@@ -63,7 +65,7 @@ export default function AdminItems({ locationId }: Props) {
       .eq("id", id);
 
     if (error) {
-      alert("변경 저장 실패: " + error.message);
+      toast("변경 저장 실패: " + error.message);
     }
   };
 
@@ -79,7 +81,7 @@ export default function AdminItems({ locationId }: Props) {
 
     const existing = locationItems.find((i) => i.gift_item_id === newGiftItemId);
     if (existing) {
-      alert("이미 추가된 기념품입니다.");
+      toast("이미 추가된 기념품입니다.");
       return;
     }
 
@@ -101,7 +103,7 @@ export default function AdminItems({ locationId }: Props) {
     ]);
 
     if (error) {
-      alert("추가 실패: " + error.message);
+      toast("추가 실패: " + error.message);
     } else {
       setNewGiftItemId("");
       fetchData();
@@ -265,3 +267,4 @@ export default function AdminItems({ locationId }: Props) {
     </div>
   );
 }
+

--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -4,6 +4,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
 import { Button } from "@/components/ui/button";
 import Modal from "@/components/ui/Modal";
 import { Trash2, Upload } from "lucide-react";
+import { useToast } from "@/components/ui/Toast";
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
@@ -15,6 +16,7 @@ interface Props {
 export default function ImageSelectorModal({ onSelect, onClose }: Props) {
   const [images, setImages] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
+  const toast = useToast();
 
   const fetchImages = async () => {
     const { data } = await supabase.storage.from("gift-images").list("", {
@@ -44,7 +46,7 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
     if (!error) {
       await fetchImages();
     } else {
-      alert("업로드 실패");
+      toast("업로드 실패");
     }
 
     setUploading(false);
@@ -58,7 +60,7 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
     if (!error) {
       await fetchImages();
     } else {
-      alert("삭제 실패");
+      toast("삭제 실패");
     }
   };
 
@@ -98,3 +100,4 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
     </Modal>
   );
 }
+

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { createClient } from "@supabase/supabase-js";
@@ -14,6 +15,7 @@ interface AdminLoginProps {
 export default function AdminLogin({ onBack, onLoginSuccess }: AdminLoginProps) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const toast = useToast();
 
   const handleLogin = async () => {
     const { data, error } = await supabase
@@ -23,7 +25,7 @@ export default function AdminLogin({ onBack, onLoginSuccess }: AdminLoginProps) 
       .single();
 
     if (error) {
-      alert("서버 오류가 발생했습니다.");
+      toast("서버 오류가 발생했습니다.");
       console.error(error);
       return;
     }
@@ -32,7 +34,7 @@ export default function AdminLogin({ onBack, onLoginSuccess }: AdminLoginProps) 
       localStorage.setItem("isAdmin", "true");
       onLoginSuccess();
     } else {
-      alert("아이디 또는 비밀번호가 틀렸습니다.");
+      toast("아이디 또는 비밀번호가 틀렸습니다.");
     }
   };
 
@@ -66,3 +68,4 @@ export default function AdminLogin({ onBack, onLoginSuccess }: AdminLoginProps) 
     </div>
   );
 }
+

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -8,6 +8,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import Modal from "@/components/ui/Modal";
 import StatisticsModal from "@/modals/StatisticsModal"; // 상단에 import
 import { GiftRecord } from "@/types"; // 타입 import
+import { useToast } from "@/components/ui/Toast";
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
@@ -38,6 +39,7 @@ export default function AdminRecords() {
   const [dateMode, setDateMode] = useState<"today" | "range">(() => {
     return (localStorage.getItem("dateMode") as "today" | "range") || "today";
   });
+  const toast = useToast();
   const [showLocationDropdown, setShowLocationDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [ackFilter, setAckFilter] = useState<"all" | "paid" | "unpaid">(() => {
@@ -160,7 +162,7 @@ export default function AdminRecords() {
       if (!error) {
         setRecords((prev) => prev.filter((r) => r.id !== id));
       } else {
-        alert("삭제 실패");
+        toast("삭제 실패");
       }
     }
   };
@@ -192,7 +194,7 @@ export default function AdminRecords() {
       setRecords((prev) => prev.filter((r) => !selectedRecords.has(r.id)));
       setSelectedRecords(new Set());
     } else {
-      alert("일괄 삭제 실패");
+      toast("일괄 삭제 실패");
     }
   };
 
@@ -464,3 +466,4 @@ export default function AdminRecords() {
     </div>
   );
 }
+

--- a/src/pages/BulkItemManager.tsx
+++ b/src/pages/BulkItemManager.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import Modal from "@/components/ui/Modal";
 import AdminItems from "@/modals/AdminItems";
 import GlobalItemManager from "@/pages/GlobalItemManager";
+import { useToast } from "@/components/ui/Toast";
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
@@ -20,6 +21,7 @@ export default function BulkItemManager() {
   const [selectedLocation, setSelectedLocation] = useState<Location | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("location");
+  const toast = useToast();
 
   // 동기화 관련 상태
   const [syncMode, setSyncMode] = useState(false);
@@ -67,7 +69,7 @@ export default function BulkItemManager() {
       .select("*")
       .eq("location_id", syncSourceId);
 
-    if (!sourceItems) return alert("기준 장소 기념품 정보를 불러오지 못했습니다.");
+    if (!sourceItems) return toast("기준 장소 기념품 정보를 불러오지 못했습니다.");
 
     await supabase.from("location_gift_items")
       .delete()
@@ -81,9 +83,9 @@ export default function BulkItemManager() {
     );
 
     const { error } = await supabase.from("location_gift_items").insert(payload);
-    if (error) return alert("동기화 실패: " + error.message);
+    if (error) return toast("동기화 실패: " + error.message);
 
-    alert("동기화가 완료되었습니다.");
+    toast("동기화가 완료되었습니다.");
     setSyncMode(false);
     setSyncSourceId("");
     setSyncTargetIds([]);

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useToast } from "@/components/ui/Toast";
 import { createClient } from "@supabase/supabase-js";
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
 import { Input } from "@/components/ui/input";
@@ -24,6 +25,7 @@ export default function GlobalItemManager() {
   const [showImageModal, setShowImageModal] = useState(false);
   const [editingItem, setEditingItem] = useState<GiftItem | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
+  const toast = useToast();
 
   const fetchItems = async () => {
     const { data } = await supabase.from("gift_items").select("*").order("name", { ascending: true });
@@ -36,7 +38,7 @@ export default function GlobalItemManager() {
 
   const handleAdd = async () => {
     if (!newItem.name) {
-      alert("기념품 이름을 입력해주세요.");
+      toast("기념품 이름을 입력해주세요.");
       return;
     }
 
@@ -49,7 +51,7 @@ export default function GlobalItemManager() {
     }]);
 
     if (error) {
-      alert("추가 실패: " + error.message);
+      toast("추가 실패: " + error.message);
     } else {
       setNewItem({});
       fetchItems();
@@ -62,7 +64,7 @@ export default function GlobalItemManager() {
     if (!confirm("정말 삭제하시겠습니까?")) return;
     const { error } = await supabase.from("gift_items").delete().eq("id", id);
     if (error) {
-      alert("삭제 실패: " + error.message);
+      toast("삭제 실패: " + error.message);
     } else {
       fetchItems();
     }
@@ -81,7 +83,7 @@ export default function GlobalItemManager() {
       .eq("id", editingItem.id);
 
     if (error) {
-      alert("수정 실패: " + error.message);
+      toast("수정 실패: " + error.message);
     } else {
       setShowEditModal(false);
       setEditingItem(null);
@@ -240,3 +242,4 @@ export default function GlobalItemManager() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- implement reusable toast context component
- wrap the app with `ToastProvider`
- swap `alert()` calls for toast notifications across pages and modals

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d74575864832b85b1f25325979f76