### PR TITLE
Update red styling

### DIFF
--- a/src/components/ui/Loader.tsx
+++ b/src/components/ui/Loader.tsx
@@ -9,7 +9,7 @@ export default function Loader({ className }: LoaderProps) {
   return (
     <div
       className={cn(
-        "inline-block h-5 w-5 animate-spin rounded-full border-2 border-warmGray-300 border-t-redCrossRed-600",
+        "inline-block h-5 w-5 animate-spin rounded-full border-2 border-warmGray-300 border-t-redCrossRed",
         className
       )}
     />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,10 +11,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 px-4 py-2";
 
     const variantClasses = {
-      default: "bg-redCrossRed-600 text-white hover:bg-redCrossRed-700 focus:ring-redCrossRed-500",
+      default: "bg-redCrossRed text-white hover:bg-redCrossRed focus:ring-redCrossRed",
       ghost: "bg-transparent text-black hover:bg-warmGray-100 border border-warmGray-300 focus:ring-warmGray-300",
       subtle: "bg-warmGray-100 text-warmGray-800 hover:bg-warmGray-200 border border-warmGray-300 focus:ring-warmGray-300",
-      danger: "bg-redCrossRed-100 text-redCrossRed-700 hover:bg-redCrossRed-200 border border-redCrossRed-300 focus:ring-redCrossRed-300",
+      danger: "bg-redCrossRed/10 text-redCrossRed hover:bg-redCrossRed/20 border border-redCrossRed/30 focus:ring-redCrossRed/30",
       soft: "bg-white text-warmGray-800 border border-warmGray-200 shadow-sm hover:bg-warmGray-50 focus:ring-warmGray-300"
     };
 

--- a/src/modals/AdminItems.tsx
+++ b/src/modals/AdminItems.tsx
@@ -214,7 +214,7 @@ export default function AdminItems({ locationId }: Props) {
                 <Button
                   size="icon"
                   variant="ghost"
-                  className="text-redCrossRed-500 ml-auto"
+                  className="text-redCrossRed ml-auto"
                   onClick={() => handleDelete(item.id)}
                   aria-label="항목 삭제"
                 >

--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -85,7 +85,7 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
               onClick={() => handleDelete(url)}
               aria-label="이미지 삭제"
             >
-              <Trash2 size={14} className="text-redCrossRed-500" />
+              <Trash2 size={14} className="text-redCrossRed" />
             </button>
           </div>
         ))}

--- a/src/modals/StatisticsModal.tsx
+++ b/src/modals/StatisticsModal.tsx
@@ -40,7 +40,7 @@ export default function StatisticsModal({ data }: Props) {
                 <XAxis dataKey="name" />
                 <YAxis allowDecimals={false} />
                 <Tooltip />
-                <Bar dataKey="count" fill="#d62828" />
+                <Bar dataKey="count" fill="theme('colors.redCrossRed')" />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -434,7 +434,7 @@ export default function AdminRecords() {
                     e.stopPropagation();
                     handleDelete(record.id);
                   }}
-                  className="absolute top-3 right-3 text-warmGray-400 hover:text-redCrossRed-500"
+                  className="absolute top-3 right-3 text-warmGray-400 hover:text-redCrossRed"
                   aria-label="기록 삭제"
                 >
                   <Trash2 size={16} />

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -178,7 +178,7 @@ export default function GlobalItemManager() {
                 <Button
                   variant="ghost"
                   onClick={() => handleDelete(item.id)}
-                  className="text-redCrossRed-500"
+                  className="text-redCrossRed"
                   aria-label="삭제"
                 >
                   <Trash2 size={16} />


### PR DESCRIPTION
## Summary
- update loader spinner to use `border-t-redCrossRed`
- use Tailwind theme color for bar chart fill
- switch all `*-redCrossRed-*` utility classes to single shade `redCrossRed`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f81ee0f34832bb8bf6d2df60c45d6