### PR TITLE
Add redCrossWarmGray palette and update usages

### DIFF
--- a/src/components/ui/Loader.tsx
+++ b/src/components/ui/Loader.tsx
@@ -9,7 +9,7 @@ export default function Loader({ className }: LoaderProps) {
   return (
     <div
       className={cn(
-        "inline-block h-5 w-5 animate-spin rounded-full border-2 border-warmGray-300 border-t-redCrossRed",
+        "inline-block h-5 w-5 animate-spin rounded-full border-2 border-redCrossWarmGray-300 border-t-redCrossRed",
         className
       )}
     />

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -74,7 +74,7 @@ export default function Modal({ children, onClose }: Props) {
         {/* 상단 우측 닫기 버튼 */}
         <button
           onClick={onClose}
-          className="absolute top-3 right-3 text-warmGray-400 hover:text-black text-2xl font-bold w-10 h-10 flex items-center justify-center rounded-full hover:bg-warmGray-200 transition"
+          className="absolute top-3 right-3 text-redCrossWarmGray-400 hover:text-black text-2xl font-bold w-10 h-10 flex items-center justify-center rounded-full hover:bg-redCrossWarmGray-200 transition"
           aria-label="닫기"
         >
           ✕

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -31,7 +31,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           <div
             key={t.id}
             className={cn(
-              "bg-warmGray-900 text-white px-4 py-2 rounded shadow-md transition-opacity"
+              "bg-redCrossWarmGray-900 text-white px-4 py-2 rounded shadow-md transition-opacity"
             )}
           >
             {t.message}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,10 +12,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     const variantClasses = {
       default: "bg-redCrossRed text-white hover:bg-redCrossRed focus:ring-redCrossRed",
-      ghost: "bg-transparent text-black hover:bg-warmGray-100 border border-warmGray-300 focus:ring-warmGray-300",
-      subtle: "bg-warmGray-100 text-warmGray-800 hover:bg-warmGray-200 border border-warmGray-300 focus:ring-warmGray-300",
+      ghost: "bg-transparent text-black hover:bg-redCrossWarmGray-100 border border-redCrossWarmGray-300 focus:ring-redCrossWarmGray-300",
+      subtle: "bg-redCrossWarmGray-100 text-redCrossWarmGray-800 hover:bg-redCrossWarmGray-200 border border-redCrossWarmGray-300 focus:ring-redCrossWarmGray-300",
       danger: "bg-redCrossRed/10 text-redCrossRed hover:bg-redCrossRed/20 border border-redCrossRed/30 focus:ring-redCrossRed/30",
-      soft: "bg-white text-warmGray-800 border border-warmGray-200 shadow-sm hover:bg-warmGray-50 focus:ring-warmGray-300"
+      soft: "bg-white text-redCrossWarmGray-800 border border-redCrossWarmGray-200 shadow-sm hover:bg-redCrossWarmGray-50 focus:ring-redCrossWarmGray-300"
     };
 
     return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...pr
     <input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-warmGray-300 bg-white px-3 py-2 text-sm text-black placeholder:text-warmGray-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md border border-redCrossWarmGray-300 bg-white px-3 py-2 text-sm text-black placeholder:text-redCrossWarmGray-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/modals/AdminItems.tsx
+++ b/src/modals/AdminItems.tsx
@@ -153,7 +153,7 @@ export default function AdminItems({ locationId }: Props) {
             <div
               key={item.id}
               className={`relative p-4 border rounded shadow flex flex-col gap-2 transition
-                ${item.visible ? "bg-white" : "bg-warmGray-100 opacity-50"}
+                ${item.visible ? "bg-white" : "bg-redCrossWarmGray-100 opacity-50"}
               `}
             >
               {/* 정렬 버튼 상단 우측 배치 */}
@@ -231,7 +231,7 @@ export default function AdminItems({ locationId }: Props) {
   return (
     <div>
       {/* 추가 폼 */}
-      <div className="border p-4 rounded mb-6 space-y-3 bg-warmGray-50">
+      <div className="border p-4 rounded mb-6 space-y-3 bg-redCrossWarmGray-50">
         <h3 className="font-semibold text-lg">기념품 추가</h3>
         <select
           value={newGiftItemId}

--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -92,7 +92,7 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
       </div>
 
       <div className="mt-4">
-        <label className="flex items-center gap-2 text-sm text-warmGray-600">
+        <label className="flex items-center gap-2 text-sm text-redCrossWarmGray-600">
           <Upload size={16} />
           이미지 업로드:
           <input type="file" onChange={handleUpload} disabled={uploading} />

--- a/src/modals/StatisticsModal.tsx
+++ b/src/modals/StatisticsModal.tsx
@@ -30,7 +30,7 @@ export default function StatisticsModal({ data }: Props) {
       <h1 className="text-lg font-bold mb-4">기념품 통계</h1>
 
       {chartData.length === 0 ? (
-        <p className="text-center text-warmGray-400">데이터가 없습니다.</p>
+        <p className="text-center text-redCrossWarmGray-400">데이터가 없습니다.</p>
       ) : (
         <>
           {/* Chart */}
@@ -51,7 +51,7 @@ export default function StatisticsModal({ data }: Props) {
             <div className="overflow-x-auto">
               <table className="w-full text-sm border min-w-[300px]">
                 <thead>
-                  <tr className="bg-warmGray-100">
+                  <tr className="bg-redCrossWarmGray-100">
                     <th className="text-left px-4 py-2 border">기념품</th>
                     <th className="text-right px-4 py-2 border">선택 수</th>
                   </tr>

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -314,7 +314,7 @@ export default function AdminRecords() {
             )}
           </div>
           {selectedLocations.length > 0 && (
-            <div className="text-sm text-warmGray-600">
+            <div className="text-sm text-redCrossWarmGray-600">
               선택됨: {selectedLocations.map((id) => locations.find((l) => l.id === id)?.name).join(", ")}
             </div>
           )}
@@ -367,7 +367,7 @@ export default function AdminRecords() {
         </Button>
 
         {/* 선택 및 항목 수 */}
-        <div className="flex justify-between items-center text-sm text-warmGray-500">
+        <div className="flex justify-between items-center text-sm text-redCrossWarmGray-500">
           <label className="flex items-center gap-2">
             <input
               type="checkbox"
@@ -382,7 +382,7 @@ export default function AdminRecords() {
 
       {/* 결과 리스트 */}
       {filteredRecords.length === 0 ? (
-        <p className="text-warmGray-500 text-center">기록이 없습니다.</p>
+        <p className="text-redCrossWarmGray-500 text-center">기록이 없습니다.</p>
       ) : (
         <div className="space-y-4">
           {filteredRecords.map((record) => {
@@ -403,10 +403,10 @@ export default function AdminRecords() {
                 key={record.id}
                 className={`relative border rounded-lg p-4 shadow-sm cursor-pointer transition duration-500 ${
                   isAcknowledged
-                    ? "bg-warmGray-100 opacity-70"
+                    ? "bg-redCrossWarmGray-100 opacity-70"
                     : isHighlighted
                     ? "animate-highlight"
-                    : "bg-white hover:bg-warmGray-50"
+                    : "bg-white hover:bg-redCrossWarmGray-50"
                 }`}
                 onClick={() => toggleAcknowledge(record.id, record.is_paid || false)} // "확인함" 상태를 토글하는 부분
               >
@@ -434,15 +434,15 @@ export default function AdminRecords() {
                     e.stopPropagation();
                     handleDelete(record.id);
                   }}
-                  className="absolute top-3 right-3 text-warmGray-400 hover:text-redCrossRed"
+                  className="absolute top-3 right-3 text-redCrossWarmGray-400 hover:text-redCrossRed"
                   aria-label="기록 삭제"
                 >
                   <Trash2 size={16} />
                 </button>
 
                 <div className="ml-6 mb-1 flex flex-wrap items-center gap-2">
-                  <span className="font-semibold text-warmGray-800">{record.name}</span>
-                  <span className="text-xs text-warmGray-500">
+                  <span className="font-semibold text-redCrossWarmGray-800">{record.name}</span>
+                  <span className="text-xs text-redCrossWarmGray-500">
                     {new Date(record.timestamp || "").toLocaleString("ko-KR", {
                       year: "2-digit",
                       month: "2-digit",
@@ -451,14 +451,14 @@ export default function AdminRecords() {
                       minute: "2-digit",
                     })}
                   </span>
-                  <span className="text-xs text-warmGray-400">({locationName})</span>
+                  <span className="text-xs text-redCrossWarmGray-400">({locationName})</span>
                 </div>
 
                 <div className="grid grid-cols-2 gap-2 mt-2">
                   {items.map((item, i) => (
                     <div
                       key={i}
-                      className="flex justify-between items-center px-3 py-2 bg-warmGray-50 border rounded text-sm text-warmGray-700 shadow-inner"
+                      className="flex justify-between items-center px-3 py-2 bg-redCrossWarmGray-50 border rounded text-sm text-redCrossWarmGray-700 shadow-inner"
                     >
                       <span>{item}</span>
                     </div>

--- a/src/pages/BulkItemManager.tsx
+++ b/src/pages/BulkItemManager.tsx
@@ -167,7 +167,7 @@ export default function BulkItemManager() {
               {locations.map((loc) => (
                 <div key={loc.id} className="border rounded p-4 shadow flex flex-col gap-2">
                   <h4 className="font-semibold text-lg">{loc.name}</h4>
-                  <div className="text-sm text-warmGray-500">
+                  <div className="text-sm text-redCrossWarmGray-500">
                     {(locationItemMap[loc.id]?.slice(0, 3) || []).join(", ")}
                     {locationItemMap[loc.id]?.length > 3 &&
                       ` 외 ${locationItemMap[loc.id].length - 3}개`}

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -160,7 +160,7 @@ export default function GlobalItemManager() {
                 <div className="flex flex-col">
                   <span className="font-medium">{item.name}</span>
                   {item.description && (
-                    <span className="text-sm text-warmGray-500">{item.description}</span>
+                    <span className="text-sm text-redCrossWarmGray-500">{item.description}</span>
                   )}
                 </div>
               </div>

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -151,7 +151,7 @@ export default function MainLayout() {
             <h2 className="text-lg font-bold">메뉴</h2>
             <button
               onClick={() => setSidebarOpen(false)}
-              className="text-warmGray-500 hover:text-black"
+              className="text-redCrossWarmGray-500 hover:text-black"
               aria-label="메뉴 닫기"
             >
               &times;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,3 @@
-import colors from "tailwindcss/colors";
 
 export default {
   content: [
@@ -9,7 +8,30 @@ export default {
     extend: {
       colors: {
         redCrossRed: '#d62828',
-        redCrossWarmGray: '#9b8f8b',
+        redCrossWarmGray: {
+          50: '#f5f5f4',
+          100: '#e7e5e4',
+          200: '#d6d3d1',
+          300: '#a8a29e',
+          400: '#78716c',
+          500: '#57534e',
+          600: '#44403c',
+          700: '#292524',
+          800: '#1c1917',
+          900: '#0c0a09'
+        },
+        warmGray: {
+          50: '#f5f5f4',
+          100: '#e7e5e4',
+          200: '#d6d3d1',
+          300: '#a8a29e',
+          400: '#78716c',
+          500: '#57534e',
+          600: '#44403c',
+          700: '#292524',
+          800: '#1c1917',
+          900: '#0c0a09'
+        },
         redCrossGray: '#8c8c8c',
         redCrossGold: '#d4af37',
         redCrossSilver: '#c0c0c0',


### PR DESCRIPTION
## Summary
- define `redCrossWarmGray` shades in Tailwind config and keep `warmGray` alias
- replace all `warmGray-*` classes with `redCrossWarmGray-*`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa4b3b4d8832b92d73e611156c58e