### PR TITLE
Update highlight animation colors

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,10 @@ export default {
         redCrossRed: '#d62828',
         redCrossWarmGray: '#9b8f8b',
         redCrossGray: '#8c8c8c',
-        redCrossGold: '#d4af37',
+        redCrossGold: {
+          DEFAULT: '#d4af37',
+          light: '#fbe8b0',
+        },
         redCrossSilver: '#c0c0c0',
       },
       fontSize: {
@@ -26,8 +29,8 @@ export default {
       },
       keyframes: {
         highlight: {
-          '0%, 100%': { backgroundColor: '#f9e5a7' },
-          '50%': { backgroundColor: '#c79e2e' },
+          '0%, 100%': { backgroundColor: '#fbe8b0' },
+          '50%': { backgroundColor: '#d4af37' },
         },
       },
       animation: {


### PR DESCRIPTION
## Summary
- add a light variant for `redCrossGold`
- use the light and base `redCrossGold` colors in the `highlight` keyframes

## Testing
- `npm install` *(fails: 403 Forbidden, likely due to network restrictions)*
- `npm run build` *(fails: `vite: not found` because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fa4b7bc58832b823e96cdafddfb98