### PR TITLE
Update color palette docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ npm run build
 | Red Cross Gold    | #d4af37 | 강조용 아이콘이나 특별한 요소에 사용합니다. 밝은 톤을 원할 경우 `opacity-80` 등을 적용합니다. |
 | Red Cross Silver  | #c0c0c0 | 테두리나 배경 등에 사용하며, `opacity`를 조절해 밝기를 변경할 수 있습니다. |
 
+### 단계별 색상 예시
+
+| 단계 | redCrossRed | redCrossWarmGray | redCrossGray | redCrossGold | redCrossSilver |
+|-----|-------------|------------------|--------------|--------------|----------------|
+| 50  | #fdeaea | #f5f4f4 | #f5f5f5 | #fff9e2 | #f8f8f8 |
+| 100 | #f6c0c0 | #e6e3e2 | #e2e2e2 | #fceebf | #ececec |
+| 200 | #f09999 | #d8d4d3 | #cfcfcf | #f8e29c | #dfdfdf |
+| 300 | #ea7373 | #c9c0be | #bcbcbc | #f3d679 | #d3d3d3 |
+| 400 | #e44c4c | #bbaead | #a9a9a9 | #efcb56 | #c6c6c6 |
+| 500 | #d62828 | #9b8f8b | #8c8c8c | #d4af37 | #c0c0c0 |
+| 600 | #b52222 | #867a78 | #707070 | #b5932c | #a2a2a2 |
+| 700 | #941b1b | #706563 | #565656 | #967822 | #858585 |
+| 800 | #741515 | #5b504f | #3d3d3d | #785d17 | #676767 |
+| 900 | #530f0f | #453b3a | #222222 | #5a430d | #4a4a4a |
+
+### 주요 클래스 예시
+
+- 버튼: `bg-redCrossRed-600 hover:bg-redCrossRed-700 text-white`
+- 테이블 헤더: `bg-redCrossWarmGray-100 text-redCrossWarmGray-800`
+- 경고 텍스트: `text-redCrossRed-500`
+
 ### 예시
 
 ```tsx
@@ -47,3 +68,7 @@ export default function ExampleButton() {
 ```
 
 위 예시는 `redCrossRed` 컬러를 배경으로 사용하고, hover 시 약간 투명도를 줘서 음영을 표현하는 방법을 보여줍니다.
+
+### 색상 체계 확장 안내
+
+`tailwind.config.ts`의 `theme.extend.colors`에 위 표의 각 단계가 모두 정의되어 있습니다. 프로젝트에서는 이러한 사용자 정의 색상만 사용하며, 기본 Tailwind 색상과 혼용하지 않는 것을 원칙으로 합니다.


### PR DESCRIPTION
## Summary
- document shade variants for Red Cross colors
- add common utility class examples
- mention how color scheme is extended and used exclusively

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa4bac5a8832bab1348537a56ecb0