### PR TITLE
Fix body overflow with multiple modals

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
+// 전역 모달 개수 카운터와 body overflow 보존 변수
+let openModals = 0;
+let originalBodyOverflow = "";
+
 interface Props {
   children: React.ReactNode;
   onClose: () => void;
@@ -10,8 +14,12 @@ export default function Modal({ children, onClose }: Props) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    // 모달이 처음 열릴 때 body overflow 상태를 보존하고 숨김 처리
+    if (openModals === 0) {
+      originalBodyOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    }
+    openModals++;
 
     const previouslyFocused = document.activeElement as HTMLElement | null;
     const selector =
@@ -56,7 +64,11 @@ export default function Modal({ children, onClose }: Props) {
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = originalOverflow;
+      openModals--;
+      // 모든 모달이 닫혔을 때만 overflow 복원
+      if (openModals === 0) {
+        document.body.style.overflow = originalBodyOverflow;
+      }
       previouslyFocused?.focus();
     };
   }, [onClose]);


### PR DESCRIPTION
## Summary
- ensure body overflow isn't reset until all modals close

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685faddebcb0832bb5685b695e66b4f2