### PR TITLE
Use lucide-react icon for Modal close button

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { X } from "lucide-react";
 
 interface Props {
   children: React.ReactNode;
@@ -77,7 +78,7 @@ export default function Modal({ children, onClose }: Props) {
           className="absolute top-3 right-3 text-redCrossWarmGray-400 hover:text-black text-2xl font-bold w-10 h-10 flex items-center justify-center rounded-full hover:bg-redCrossWarmGray-200 transition"
           aria-label="닫기"
         >
-          ✕
+          <X size={20} />
         </button>
 
         {/* 컨텐츠 */}


### PR DESCRIPTION
## Summary
- import `X` icon from lucide-react
- replace text close button with `<X>` icon

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685faea036f4832b8113723392aed39a