### PR TITLE
Add hover and focus styles to image selector

### DIFF
--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -70,7 +70,10 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
 
       <div className="grid grid-cols-3 gap-3 max-h-[400px] overflow-y-auto">
         {images.map((url) => (
-          <div key={url} className="relative group border rounded p-1">
+          <div
+            key={url}
+            className="relative group border rounded p-1 hover:ring-2 hover:ring-redCrossRed focus-within:ring-2"
+          >
             <img
               src={url}
               alt="img"
@@ -81,7 +84,7 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
               }}
             />
             <button
-              className="absolute top-1 right-1 bg-white p-1 rounded-full shadow hidden group-hover:block"
+              className="absolute top-1 right-1 bg-white p-1 rounded-full shadow hidden group-hover:block group-focus:block"
               onClick={() => handleDelete(url)}
               aria-label="이미지 삭제"
             >


### PR DESCRIPTION
## Summary
- highlight image containers on hover or focus
- display delete button when group is hovered or focused

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685faea4dd14832bad6a51ed1a422911