### PR TITLE
Add configurable modal width

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -10,9 +10,16 @@ interface Props {
   children: React.ReactNode;
   onClose: () => void;
   labelledBy?: string;
+  /** 최대 너비에 적용할 tailwind 클래스 */
+  maxWidthClass?: string;
 }
 
-export default function Modal({ children, onClose, labelledBy }: Props) {
+export default function Modal({
+  children,
+  onClose,
+  labelledBy,
+  maxWidthClass = "max-w-[95vw] sm:max-w-xl md:max-w-4xl",
+}: Props) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -85,7 +92,7 @@ export default function Modal({ children, onClose, labelledBy }: Props) {
     >
       <div
         ref={modalRef}
-        className="w-full max-w-3xl rounded-lg bg-white shadow-lg relative p-6 my-10" // 상단 마진만 고정
+        className={`w-full ${maxWidthClass} rounded-lg bg-white shadow-lg relative p-6 my-10`} // 상단 마진만 고정
         onClick={(e) => e.stopPropagation()}
       >
         {/* 상단 우측 닫기 버튼 */}

--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -66,7 +66,11 @@ export default function ImageSelectorModal({ onSelect, onClose }: Props) {
   };
 
   return (
-    <Modal onClose={onClose} labelledBy="image-selector-title">
+    <Modal
+      onClose={onClose}
+      labelledBy="image-selector-title"
+      maxWidthClass="max-w-[95vw] sm:max-w-3xl md:max-w-5xl"
+    >
       <h2 id="image-selector-title" className="text-lg font-semibold mb-4">
         이미지 선택
       </h2>

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -475,6 +475,7 @@ export default function AdminRecords() {
         <Modal
           onClose={() => setShowModal(false)}
           labelledBy="statistics-modal-title"
+          maxWidthClass="max-w-[95vw] sm:max-w-xl md:max-w-5xl"
         >
           <StatisticsModal
             data={filteredRecords}

--- a/src/pages/BulkItemManager.tsx
+++ b/src/pages/BulkItemManager.tsx
@@ -182,6 +182,7 @@ export default function BulkItemManager() {
             <Modal
               onClose={() => setShowModal(false)}
               labelledBy="location-modal-title"
+              maxWidthClass="max-w-[95vw] sm:max-w-2xl md:max-w-5xl"
             >
               <h3 id="location-modal-title" className="text-lg font-semibold mb-3">
                 {selectedLocation.name}의 기념품 관리

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -216,6 +216,7 @@ export default function GlobalItemManager() {
         <Modal
           onClose={() => setShowEditModal(false)}
           labelledBy="edit-item-modal-title"
+          maxWidthClass="max-w-[95vw] sm:max-w-xl md:max-w-3xl"
         >
           <h3 id="edit-item-modal-title" className="text-lg font-semibold mb-4">
             기념품 편집


### PR DESCRIPTION
## Summary
- add `maxWidthClass` prop to `Modal` component with sensible defaults
- update modal usage sites to specify width

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbaf3c1ec832b9e5b8f21ee1d0a27