### PR TITLE
Fix manifest path and cleanup webmanifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="icon" href="/favicon.ico" />
-    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="manifest" href="/rc-kiosk-admin-app/site.webmanifest" />
     <meta property="og:title" content="기념품 키오스크 관리" />
     <meta property="og:description" content="기념품 키오스크를 관리하는 관리자용 웹 애플리케이션" />
     <meta property="og:type" content="website" />

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,18 +1,6 @@
 {
   "name": "기념품 키오스크 관리",
   "short_name": "키오스크 관리",
-  "icons": [
-    {
-      "src": "/rc-kiosk-admin-app/android-chrome-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/rc-kiosk-admin-app/android-chrome-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
-  ],
   "start_url": "/rc-kiosk-admin-app/",
   "display": "standalone",
   "theme_color": "#ffffff",


### PR DESCRIPTION
## Summary
- point manifest href to the correct path
- remove unused icons from the PWA manifest

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc60dee60832ba9e87c95077a4469