### PR TITLE
Refactor Supabase client usage

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from '@/lib/supabaseConfig';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+export default supabase;

--- a/src/modals/AdminItems.tsx
+++ b/src/modals/AdminItems.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowUp, ArrowDown, Trash2 } from "lucide-react";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 import { useToast } from "@/components/ui/Toast";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface GiftItem {
   id: string;

--- a/src/modals/ImageSelectorModal.tsx
+++ b/src/modals/ImageSelectorModal.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState, useRef } from "react";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import Modal from "@/components/ui/Modal";
 import { Trash2, Upload } from "lucide-react";
 import { useToast } from "@/components/ui/Toast";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface Props {
   onSelect: (url: string) => void;

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -2,10 +2,8 @@ import { useState } from "react";
 import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface AdminLoginProps {
   onBack: () => void;

--- a/src/pages/AdminRecords.tsx
+++ b/src/pages/AdminRecords.tsx
@@ -2,8 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import Loader from "@/components/ui/Loader";
 import { Trash2 } from "lucide-react";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import Modal from "@/components/ui/Modal";
@@ -11,7 +10,6 @@ import StatisticsModal from "@/modals/StatisticsModal"; // 상단에 import
 import { GiftRecord } from "@/types"; // 타입 import
 import { useToast } from "@/components/ui/Toast";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface Location {
   id: string;

--- a/src/pages/BulkItemManager.tsx
+++ b/src/pages/BulkItemManager.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from "react";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import Modal from "@/components/ui/Modal";
 import AdminItems from "@/modals/AdminItems";
 import GlobalItemManager from "@/pages/GlobalItemManager";
 import { useToast } from "@/components/ui/Toast";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface Location {
   id: string;

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useToast } from "@/components/ui/Toast";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -10,7 +9,6 @@ import { Trash2, Pencil } from "lucide-react";
 import ImageSelectorModal from "@/modals/ImageSelectorModal";
 import Modal from "@/components/ui/Modal";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface GiftItem {
   id: string;

--- a/src/pages/KioskLinks.tsx
+++ b/src/pages/KioskLinks.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from "react";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import QRCode from "qrcode.react";
 import { Download } from "lucide-react";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 interface Location {
   id: string;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -14,10 +14,8 @@ import AdminRecords from "./AdminRecords";
 import AdminLogin from "./AdminLogin";
 import BulkItemManager from "./BulkItemManager";
 import KioskLinks from "./KioskLinks";
-import { createClient } from "@supabase/supabase-js";
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/supabaseConfig";
+import supabase from "@/lib/supabaseClient";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 export default function MainLayout() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- export a single Supabase client from `src/lib/supabaseClient.ts`
- use the shared client across pages and modals

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc60f1a14832b92e869f9e5d6e43e