### PR TITLE
Improve form accessibility with ids and labels

### DIFF
--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -42,20 +42,22 @@ export default function AdminLogin({ onBack, onLoginSuccess }: AdminLoginProps) 
     <div className="flex justify-center items-center h-full relative">
       <div className="w-full max-w-sm bg-white p-6 rounded-lg shadow space-y-4">
         <h1 className="text-xl font-semibold text-center">로그인</h1>
-        <label className="block space-y-1">
+        <label className="block space-y-1" htmlFor="username">
           <span className="sr-only">아이디</span>
           <Input
             type="text"
+            id="username"
             placeholder="아이디"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             className="text-base"
           />
         </label>
-        <label className="block space-y-1">
+        <label className="block space-y-1" htmlFor="password">
           <span className="sr-only">비밀번호</span>
           <Input
             type="password"
+            id="password"
             placeholder="비밀번호"
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/src/pages/GlobalItemManager.tsx
+++ b/src/pages/GlobalItemManager.tsx
@@ -103,9 +103,10 @@ export default function GlobalItemManager() {
       <div className="border rounded p-4 shadow bg-white space-y-3">
         <h3 className="font-semibold text-lg">기념품 항목 추가</h3>
 
-        <label className="block space-y-1">
+        <label className="block space-y-1" htmlFor="new-item-name">
           <span className="sr-only">기념품 이름</span>
           <Input
+            id="new-item-name"
             placeholder="기념품 이름"
             value={newItem.name ?? ""}
             onChange={(e) =>
@@ -222,9 +223,10 @@ export default function GlobalItemManager() {
             기념품 편집
           </h3>
 
-          <label className="block space-y-1">
+          <label className="block space-y-1" htmlFor="edit-item-name">
             <span className="sr-only">이름</span>
             <Input
+              id="edit-item-name"
               value={editingItem.name}
               onChange={(e) =>
                 setEditingItem({ ...editingItem, name: e.target.value })


### PR DESCRIPTION
## Summary
- add `htmlFor` and `id` attributes to login inputs
- link item name inputs with labels in the item manager

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc60ff344832b973cf5802239aff4