### PR TITLE
Remove PWA favicon and preview tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,20 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="기념품 키오스크를 관리하는 관리자용 웹 애플리케이션" />
     <meta name="theme-color" content="#ffffff" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta property="og:title" content="기념품 키오스크 관리" />
     <meta property="og:description" content="기념품 키오스크를 관리하는 관리자용 웹 애플리케이션" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/social-preview.png" />
     <meta property="og:url" content="/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="기념품 키오스크 관리" />
     <meta name="twitter:description" content="기념품 키오스크를 관리하는 관리자용 웹 애플리케이션" />
-    <meta name="twitter:image" content="/social-preview.png" />
     <title>기념품 키오스크 관리</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- clean up `index.html` by removing references to unused favicons and social media preview images

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc8ba584c832ba13b1746d481d471